### PR TITLE
Update "protobufjs" to be a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
   "dependencies": {
     "fast-deep-equal": "^3.1.1",
     "functional-red-black-tree": "^1.0.1",
-    "google-gax": "^2.9.2"
+    "google-gax": "^2.9.2",
+    "protobufjs": "^6.8.6"
   },
   "devDependencies": {
     "@types/assert": "^1.4.0",
@@ -79,7 +80,6 @@
     "length-prefixed-json-stream": "^1.0.1",
     "linkinator": "^2.0.0",
     "mocha": "^7.0.0",
-    "protobufjs": "^6.8.6",
     "proxyquire": "^2.1.3",
     "sinon": "^9.0.2",
     "ts-node": "^9.0.0",


### PR DESCRIPTION
Using Yarn 2 in PnP mode will break this package as it seems to require "protobufjs" in runtime code, while it's not specified as a dependency, resulting in 
> "@google-cloud/firestore tried to access protobufjs, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound"

I did not open an issue for this beforehand as the problem it's trying to solve seems obvious

You can view more info on this here: https://yarnpkg.com/configuration/yarnrc#packageExtensions and here https://yarnpkg.com/features/pnp